### PR TITLE
fix: rewrite install scripts for end-to-end CLI install

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -14,20 +14,13 @@ Before installing ePost-Kit CLI, ensure you have:
 ### Verify Prerequisites
 
 ```bash
-# Check Node.js version
 node --version  # Should be >= v18.0.0
-
-# Check npm
 npm --version
-
-# Check GitHub CLI
 gh --version
-
-# Check GitHub authentication
 gh auth status
 ```
 
-If `gh auth status` fails, authenticate with:
+If `gh auth status` fails:
 
 ```bash
 gh auth login
@@ -35,7 +28,7 @@ gh auth login
 
 ## One-Line Installation
 
-**Note:** This repository is private. You must authenticate with GitHub CLI first: `gh auth login`
+**Note:** This repository is private. You must authenticate first: `gh auth login`
 
 ### macOS / Linux
 
@@ -55,45 +48,74 @@ $script = gh api repos/Klara-copilot/epost-agent-kit-cli/contents/install/instal
 gh api repos/Klara-copilot/epost-agent-kit-cli/contents/install/install.cmd --jq .content > %TEMP%\install-epost-b64.txt && certutil -decode %TEMP%\install-epost-b64.txt %TEMP%\install-epost.cmd && %TEMP%\install-epost.cmd
 ```
 
+The installer will:
+1. Clone the CLI repo to `~/.epost-kit/cli/`
+2. Build from source (`npm install && npm run build`)
+3. Link globally (`npm link`)
+4. Verify `epost-kit --version`
+
+Re-running the installer on an existing installation does a `git pull` + rebuild instead of re-cloning.
+
 ## Verify Installation
 
-After installation completes, verify the CLI is working:
+```bash
+epost-kit --version
+epost-kit doctor
+epost-kit --help
+```
+
+## Directory Layout
+
+```
+~/.epost-kit/
+├── cli/        ← cloned CLI repo (enables git pull upgrades)
+├── packages/   ← kit data (managed by epost-kit init)
+├── profiles/   ← profiles (managed by epost-kit init)
+└── cache/      ← release cache
+```
+
+## Upgrading
 
 ```bash
-# Check version
-epost-kit --version
+epost-kit upgrade
+```
 
-# Run diagnostics
-epost-kit doctor
+This does `git pull origin master` + `npm install` + `npm run build` inside `~/.epost-kit/cli/`.
 
-# Show help
-epost-kit --help
+Options:
+- `--check` — report if update available, don't install
+- `--yes` — skip confirmation prompt
+
+**Manual upgrade:**
+
+```bash
+cd ~/.epost-kit/cli && git pull origin master && npm install && npm run build
+```
+
+## Manual Installation
+
+If the automated installer fails:
+
+```bash
+# Clone to persistent location
+gh repo clone Klara-copilot/epost-agent-kit-cli ~/.epost-kit/cli -- --branch master
+cd ~/.epost-kit/cli
+
+# Build
+npm install
+npm run build
+
+# Link globally (add sudo if permission error)
+npm link
 ```
 
 ## Troubleshooting
 
-### Issue: Node.js Version Too Old
-
-**Symptom:**
-```
-✗ Node.js version 16.x.x is too old
-Required: >= 18.0.0
-```
-
-**Solution:**
-1. Visit [nodejs.org](https://nodejs.org/)
-2. Download and install Node.js 18 LTS or newer
-3. Verify with `node --version`
-4. Re-run the installer
-
 ### Issue: GitHub CLI Not Installed
 
-**Symptom:**
 ```
-✗ GitHub CLI (gh) is not installed
+[ERR]  GitHub CLI (gh) not installed
 ```
-
-**Solution:**
 
 **macOS (Homebrew):**
 ```bash
@@ -110,318 +132,110 @@ sudo apt install gh
 winget install GitHub.cli
 ```
 
-**Windows (Chocolatey):**
-```cmd
-choco install gh
-```
-
 Or download from [cli.github.com](https://cli.github.com/)
 
-### Issue: Not Authenticated with GitHub
+### Issue: Not Authenticated
 
-**Symptom:**
 ```
-✗ Not authenticated with GitHub CLI
+[ERR]  Not authenticated with GitHub CLI
 ```
 
-**Solution:**
 ```bash
-# Authenticate with GitHub
 gh auth login
-
-# Follow the interactive prompts to:
-# 1. Select GitHub.com
-# 2. Choose HTTPS or SSH
-# 3. Authenticate via browser or token
-
-# Verify authentication
 gh auth status
 ```
 
 ### Issue: No Access to Repository
 
-**Symptom:**
 ```
-✗ Cannot access repository: Klara-copilot/epost_agent_kit
-```
-
-**Possible Causes:**
-1. **Private repository** - Request access from repository administrator
-2. **Organization membership** - Ensure you're a member of Klara-copilot organization
-3. **Network issues** - Check internet connectivity and GitHub status
-
-**Solution:**
-1. Verify you can access the repository in a browser:
-   ```
-   https://github.com/Klara-copilot/epost_agent_kit
-   ```
-2. Request organization membership if needed
-3. Verify authentication: `gh auth status`
-4. Check organization access: `gh org list`
-
-### Issue: Build Failures
-
-**Symptom:**
-```
-✗ Build failed
-npm ERR! code ELIFECYCLE
+[ERR]  Clone failed. Check your GitHub access to Klara-copilot/epost-agent-kit-cli
 ```
 
-**Possible Causes:**
-- Corrupted npm cache
-- Missing build dependencies
-- Insufficient disk space
+1. Verify you're a member of the Klara-copilot organization
+2. Check authentication: `gh auth status`
+3. Check org access: `gh org list`
 
-**Solution:**
+### Issue: Node.js Version Too Old
 
-**Clear npm cache:**
+```
+[ERR]  Node.js >= 18 required
+```
+
+Download Node.js 18 LTS or newer from [nodejs.org](https://nodejs.org/).
+
+### Issue: Permission Error on npm link
+
+```
+[ERR]  npm link failed
+```
+
+Run manually with sudo:
 ```bash
-npm cache clean --force
+cd ~/.epost-kit/cli && sudo npm link
 ```
 
-**Check disk space:**
+Or fix npm prefix permissions:
 ```bash
-df -h  # Unix/macOS
-dir    # Windows
-```
-
-**Manual build:**
-```bash
-# Clone repository
-gh repo clone Klara-copilot/epost_agent_kit
-cd epost_agent_kit/epost-agent-kit-cli
-
-# Install and build
-npm install
-npm run build
-
-# Link globally
-npm link
-# Or with sudo if permissions required
-sudo npm link
-```
-
-### Issue: Permission Errors During Install
-
-**Symptom:**
-```
-✗ Failed to install CLI globally
-npm ERR! code EACCES
-```
-
-**Solution:**
-
-**Option 1: Use sudo (macOS/Linux):**
-```bash
-sudo npm link
-```
-
-**Option 2: Fix npm permissions (recommended):**
-```bash
-# Configure npm to use user directory
 mkdir ~/.npm-global
 npm config set prefix '~/.npm-global'
-
-# Add to PATH (add to ~/.bashrc or ~/.zshrc)
-export PATH=~/.npm-global/bin:$PATH
-
-# Reload shell configuration
-source ~/.bashrc  # or source ~/.zshrc
-```
-
-**Option 3: Use package manager permissions fix:**
-```bash
-# macOS/Linux
-sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
+echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.zshrc
+source ~/.zshrc
 ```
 
 ### Issue: CLI Command Not Found After Install
 
-**Symptom:**
 ```
 epost-kit: command not found
 ```
 
-**Solution:**
-
-**1. Verify npm global bin directory:**
+Check npm global bin is in PATH:
 ```bash
 npm config get prefix
+# Add <prefix>/bin to your PATH
 ```
 
-**2. Check PATH includes npm bin:**
-```bash
-echo $PATH  # Unix/macOS
-echo %PATH% # Windows
+Restart your terminal after updating PATH.
+
+### Issue: Build Failures
+
+```
+[ERR]  npm run build failed
 ```
 
-**3. Add npm bin to PATH:**
-
-**macOS/Linux (Bash):**
+Clear npm cache and retry:
 ```bash
-echo 'export PATH="$(npm config get prefix)/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
-```
-
-**macOS/Linux (Zsh):**
-```bash
-echo 'export PATH="$(npm config get prefix)/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
-```
-
-**Windows:**
-1. Open System Properties → Advanced → Environment Variables
-2. Edit user PATH variable
-3. Add: `%APPDATA%\npm`
-4. Restart terminal
-
-**4. Restart terminal and verify:**
-```bash
-epost-kit --version
-```
-
-### Issue: Installation Hangs or Times Out
-
-**Symptom:**
-- Installer stuck on "Cloning repository..."
-- Installer stuck on "Installing dependencies..."
-
-**Solution:**
-
-**Check network connectivity:**
-```bash
-ping github.com
-curl -I https://registry.npmjs.org
-```
-
-**Use verbose mode for debugging:**
-```bash
-# Download and run with debug output
-curl -fsSL https://raw.githubusercontent.com/Klara-copilot/epost_agent_kit/main/epost-agent-kit-cli/install/install.sh > install.sh
-bash -x install.sh
-```
-
-**Configure npm proxy (if behind corporate firewall):**
-```bash
-npm config set proxy http://proxy.company.com:8080
-npm config set https-proxy http://proxy.company.com:8080
-```
-
-## Manual Installation
-
-If the automated installer fails, install manually:
-
-### Step 1: Clone Repository
-
-```bash
-gh repo clone Klara-copilot/epost_agent_kit
-cd epost_agent_kit/epost-agent-kit-cli
-```
-
-### Step 2: Install Dependencies
-
-```bash
-npm install
-```
-
-### Step 3: Build Project
-
-```bash
-npm run build
-```
-
-### Step 4: Link CLI Globally
-
-```bash
-# Try without sudo first
-npm link
-
-# If permission error, use sudo
-sudo npm link
-```
-
-### Step 5: Verify Installation
-
-```bash
-epost-kit --version
-epost-kit doctor
+npm cache clean --force
+cd ~/.epost-kit/cli && npm install && npm run build
 ```
 
 ## Uninstallation
 
-To remove ePost-Kit CLI:
-
 ```bash
-# Unlink global CLI
-npm unlink -g @klara-copilot/epost-kit
+# Remove global link
+npm unlink -g epost-kit
 
-# Or manually remove link
-rm $(which epost-kit)
-
-# Clean up global packages
-npm ls -g --depth=0
+# Remove install directory
+rm -rf ~/.epost-kit/cli
 ```
 
 ## Next Steps
 
-After successful installation:
+After installation:
 
-1. **Run diagnostics:**
-   ```bash
-   epost-kit doctor
-   ```
-
-2. **Onboard your project:**
-   ```bash
-   epost-kit onboard
-   ```
-
-3. **Explore commands:**
-   ```bash
-   epost-kit --help
-   ```
-
-4. **Initialize in existing project:**
-   ```bash
-   cd your-project
-   epost-kit init
-   ```
-
-## Getting Help
-
-- **CLI Help:** `epost-kit --help`
-- **Command Help:** `epost-kit <command> --help`
-- **Debug Mode:** `epost-kit --verbose <command>`
-- **GitHub Issues:** [Report installation issues](https://github.com/Klara-copilot/epost_agent_kit/issues)
+```bash
+epost-kit init      # Set up kit in your project
+epost-kit doctor    # Check installation health
+epost-kit --help    # Explore commands
+```
 
 ## System Requirements
 
-| Requirement | Minimum | Recommended |
-|-------------|---------|-------------|
-| Node.js | 18.0.0 | 20.x LTS |
-| npm | 9.0.0 | Latest |
-| RAM | 512MB | 1GB+ |
-| Disk Space | 100MB | 500MB |
-| OS | macOS 10.15+ / Ubuntu 20.04+ / Windows 10+ | Latest versions |
-
-## Supported Platforms
-
-- **macOS:** 10.15 (Catalina) and newer
-- **Linux:** Ubuntu 20.04+, Debian 10+, Fedora 33+, RHEL 8+
-- **Windows:** 10, 11 (PowerShell 5.1+ or PowerShell Core 7+)
-
-## Security Considerations
-
-- Installation scripts are served over HTTPS
-- GitHub CLI handles authentication securely
-- Scripts verify repository access before installation
-- Build process runs in temporary directory
-- No credentials are stored by installer
-
-## Contributing
-
-For installation script improvements, see [Contributing Guide](../README.md#contributing).
+| Requirement | Minimum |
+|-------------|---------|
+| Node.js | 18.0.0 |
+| npm | 9.0.0 |
+| OS | macOS 10.15+ / Ubuntu 20.04+ / Windows 10+ |
 
 ---
 
-**Created by:** Phuong Doan | **Last Updated:** 2026-02-12
+**Last Updated:** 2026-03-31

--- a/install/install.cmd
+++ b/install/install.cmd
@@ -1,19 +1,20 @@
 @echo off
 REM ============================================================================
-REM epost_agent_kit installer for Windows (CMD)
+REM epost-kit CLI installer for Windows (CMD)
 REM ============================================================================
-REM Downloads and installs the latest release from GitHub.
+REM Delegates to install.ps1 for full Windows support.
 REM
 REM Usage:
 REM   install.cmd
 REM
 REM Requirements:
+REM   - GitHub CLI (gh), authenticated
 REM   - Node.js >=18.0.0
-REM   - PowerShell 5.1+ (used internally for download)
+REM   - PowerShell 5.1+ (used internally)
 REM ============================================================================
 
 echo.
-echo epost_agent_kit Installer
+echo epost-kit CLI Installer
 echo.
 echo NOTE: This installer delegates to install.ps1 for full Windows support.
 echo.
@@ -25,9 +26,9 @@ if %ERRORLEVEL% neq 0 (
     echo.
     echo [ERR]  Installation failed. See errors above.
     echo.
-    echo Alternative: Install via npm directly:
-    echo   npm install -g epost-agent-kit-cli
-    echo   npx epost-agent-kit-cli init
+    echo Alternative: Clone and build manually:
+    echo   gh repo clone Klara-copilot/epost-agent-kit-cli %USERPROFILE%\.epost-kit\cli
+    echo   cd %USERPROFILE%\.epost-kit\cli ^&^& npm install ^&^& npm run build ^&^& npm link
     exit /b 1
 )
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,116 +1,146 @@
 # ============================================================================
-# epost_agent_kit installer for Windows (PowerShell)
+# epost-kit CLI installer for Windows (PowerShell)
 # ============================================================================
-# Downloads the latest release from GitHub and installs epost-kit packages.
+# Clones the CLI repo to ~/.epost-kit/cli/, builds, and links globally.
 #
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File install.ps1
 #
 # Requirements:
-#   - PowerShell 5.1+
-#   - Node.js >=18.0.0 (for epost-kit CLI)
+#   - GitHub CLI (gh), authenticated
+#   - Node.js >= 18.0.0
+#   - npm
 # ============================================================================
 
 $ErrorActionPreference = "Stop"
 
-$Repo = "Klara-copilot/epost_agent_kit"
-$VersionUrl = "https://api.github.com/repos/$Repo/releases/latest"
-$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $env:USERPROFILE ".epost" }
-$ExtractDir = Join-Path $env:TEMP "epost_install_$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+$CliRepo    = "Klara-copilot/epost-agent-kit-cli"
+$CliBranch  = "master"
+$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $env:USERPROFILE ".epost-kit" }
+$CliDir     = Join-Path $InstallDir "cli"
 
-function Write-Info  { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Cyan }
-function Write-Ok    { param([string]$Msg) Write-Host "[OK]   $Msg" -ForegroundColor Green }
-function Write-Err   { param([string]$Msg) Write-Host "[ERR]  $Msg" -ForegroundColor Red }
-function Write-Warn  { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
+function Write-Info { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundColor Cyan }
+function Write-Ok   { param([string]$Msg) Write-Host "[OK]   $Msg" -ForegroundColor Green }
+function Write-Err  { param([string]$Msg) Write-Host "[ERR]  $Msg" -ForegroundColor Red }
+function Write-Warn { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
 
-try {
-    # ========================================================================
-    # 1. Get latest release download URL
-    # ========================================================================
+# ============================================================================
+# 1. Prerequisite checks
+# ============================================================================
 
-    Write-Info "Fetching latest release info from GitHub..."
+Write-Info "Checking prerequisites..."
 
-    $Response = Invoke-WebRequest -Uri $VersionUrl -UseBasicParsing
-    $ReleaseData = $Response.Content | ConvertFrom-Json
-    $Asset = $ReleaseData.assets | Where-Object { $_.name -like "*.tar.gz" } | Select-Object -First 1
+# Check gh CLI
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Err "GitHub CLI (gh) not installed. See: https://cli.github.com/"
+    exit 1
+}
 
-    if (-not $Asset) {
-        Write-Err "Failed to find .tar.gz asset in latest release"
-        Write-Err "Check: https://github.com/$Repo/releases/latest"
+# Check gh auth
+gh auth status 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "Not authenticated with GitHub CLI. Run: gh auth login"
+    exit 1
+}
+
+# Check node >= 18
+$nodeOutput = node --version 2>$null
+if (-not $nodeOutput) {
+    Write-Err "Node.js not installed. Required: >= 18. Install from: https://nodejs.org/"
+    exit 1
+}
+$nodeVersion = $nodeOutput -replace 'v', ''
+$nodeMajor   = [int]($nodeVersion -split '\.')[0]
+if ($nodeMajor -lt 18) {
+    Write-Err "Node.js >= 18 required (found: v$nodeVersion). Upgrade at: https://nodejs.org/"
+    exit 1
+}
+
+# Check npm
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    Write-Err "npm not found"
+    exit 1
+}
+
+Write-Ok "Prerequisites OK (node v$nodeVersion)"
+
+# ============================================================================
+# 2. Clone or update CLI repo to persistent location
+# ============================================================================
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+if (Test-Path (Join-Path $CliDir ".git")) {
+    Write-Info "Existing installation found at $CliDir — updating..."
+    Set-Location $CliDir
+    git pull origin $CliBranch
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "git pull failed. Try re-running the installer."
         exit 1
     }
-
-    $ReleaseUrl = $Asset.browser_download_url
-    $Artifact = $Asset.name
-    Write-Ok "Found release: $Artifact"
-
-    # ========================================================================
-    # 2. Download artifact
-    # ========================================================================
-
-    Write-Info "Downloading $Artifact..."
-    New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
-    $DownloadPath = Join-Path $ExtractDir $Artifact
-    Invoke-WebRequest -Uri $ReleaseUrl -OutFile $DownloadPath
-    Write-Ok "Downloaded: $Artifact"
-
-    # ========================================================================
-    # 3. Extract
-    # ========================================================================
-
-    Write-Info "Extracting..."
-    # tar is available on Windows 10+ (build 17063+)
-    tar xzf $DownloadPath -C $ExtractDir
-
-    $ExtractedDir = Get-ChildItem -Directory -Path $ExtractDir -Filter "epost_agent_kit-*" | Select-Object -First 1
-
-    if (-not $ExtractedDir) {
-        Write-Err "Could not find extracted directory (expected epost_agent_kit-X.Y.Z/)"
+} else {
+    Write-Info "Cloning CLI repository to $CliDir..."
+    gh repo clone $CliRepo $CliDir -- --branch $CliBranch
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Clone failed. Check your GitHub access to $CliRepo"
         exit 1
-    }
-
-    Write-Ok "Extracted: $($ExtractedDir.Name)"
-
-    # ========================================================================
-    # 4. Install
-    # ========================================================================
-
-    Write-Info "Installing to $InstallDir..."
-    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-
-    Copy-Item -Path "$($ExtractedDir.FullName)\packages" -Destination $InstallDir -Recurse -Force
-    Copy-Item -Path "$($ExtractedDir.FullName)\.epost-metadata.json" -Destination $InstallDir -Force
-
-    if (Test-Path "$($ExtractedDir.FullName)\profiles") {
-        Copy-Item -Path "$($ExtractedDir.FullName)\profiles" -Destination $InstallDir -Recurse -Force
-    }
-    if (Test-Path "$($ExtractedDir.FullName)\templates") {
-        Copy-Item -Path "$($ExtractedDir.FullName)\templates" -Destination $InstallDir -Recurse -Force
-    }
-
-    Write-Ok "Installed to $InstallDir"
-
-    # ========================================================================
-    # 5. Done
-    # ========================================================================
-
-    Write-Host ""
-    Write-Host "Installation complete!" -ForegroundColor Green
-    Write-Host ""
-    Write-Host "  Next steps:" -ForegroundColor Cyan
-    Write-Host "    Install the CLI globally:"
-    Write-Host "      npm install -g epost-agent-kit-cli"
-    Write-Host ""
-    Write-Host "    Or use via npx:"
-    Write-Host "      npx epost-agent-kit-cli init"
-    Write-Host ""
-    Write-Host "    Then run in your project:"
-    Write-Host "      epost-kit init"
-    Write-Host ""
-
-} finally {
-    # Cleanup temp dir
-    if (Test-Path $ExtractDir) {
-        Remove-Item -Path $ExtractDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
+
+Write-Ok "Repository ready"
+
+# ============================================================================
+# 3. Build
+# ============================================================================
+
+Set-Location $CliDir
+
+Write-Info "Installing dependencies..."
+npm install
+if ($LASTEXITCODE -ne 0) { Write-Err "npm install failed"; exit 1 }
+
+Write-Info "Building..."
+npm run build
+if ($LASTEXITCODE -ne 0) { Write-Err "npm run build failed"; exit 1 }
+
+Write-Ok "Build complete"
+
+# ============================================================================
+# 4. Link globally
+# ============================================================================
+
+Write-Info "Linking CLI globally..."
+npm link
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "npm link failed. Run manually:"
+    Write-Err "  cd $CliDir"
+    Write-Err "  npm link"
+    exit 1
+}
+
+Write-Ok "CLI linked globally"
+
+# ============================================================================
+# 5. Verify installation
+# ============================================================================
+
+$versionOutput = epost-kit --version 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $versionOutput) {
+    Write-Err "Verification failed — epost-kit not found in PATH"
+    Write-Err "Restart your terminal or add npm bin to PATH."
+    exit 1
+}
+
+Write-Ok "Installed: epost-kit $versionOutput"
+
+# ============================================================================
+# 6. Done
+# ============================================================================
+
+Write-Host ""
+Write-Host "Installation complete!" -ForegroundColor Green
+Write-Host ""
+Write-Host "  Next steps:" -ForegroundColor Cyan
+Write-Host "    epost-kit init     # Set up kit in your project"
+Write-Host "    epost-kit doctor   # Check installation health"
+Write-Host ""

--- a/install/install.sh
+++ b/install/install.sh
@@ -2,24 +2,25 @@
 set -e
 
 # ============================================================================
-# epost_agent_kit installer for macOS/Linux
+# epost-kit CLI installer for macOS/Linux
 # ============================================================================
-# Downloads the latest release from GitHub and installs epost-kit packages.
+# Clones the CLI repo to ~/.epost-kit/cli/, builds, and links globally.
 #
 # Requirements:
-#   - curl
-#   - tar
-#   - Node.js >=18.0.0 (for epost-kit CLI)
+#   - GitHub CLI (gh), authenticated
+#   - Node.js >= 18.0.0
+#   - npm
 #
 # Usage:
-#   bash install-macos.sh
-#   bash <(curl -s https://raw.githubusercontent.com/Klara-copilot/epost_agent_kit/master/install-macos.sh)
+#   bash install.sh
+#   gh api repos/Klara-copilot/epost-agent-kit-cli/contents/install/install.sh \
+#     --jq .content | base64 -d | bash
 # ============================================================================
 
-REPO="Klara-copilot/epost_agent_kit"
-VERSION_URL="https://api.github.com/repos/${REPO}/releases/latest"
-INSTALL_DIR="${INSTALL_DIR:-$HOME/.epost}"
-EXTRACT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/epost_install.XXXXXX")
+CLI_REPO="Klara-copilot/epost-agent-kit-cli"
+CLI_BRANCH="master"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.epost-kit}"
+CLI_DIR="$INSTALL_DIR/cli"
 
 # ANSI color codes
 RED='\033[0;31m'
@@ -30,96 +31,121 @@ NC='\033[0m'
 
 info()    { printf "${BLUE}[INFO]${NC} %s\n" "$1"; }
 success() { printf "${GREEN}[OK]${NC}   %s\n" "$1"; }
-error()   { printf "${RED}[ERR]${NC}  %s\n" "$1"; }
+error()   { printf "${RED}[ERR]${NC}  %s\n" "$1" >&2; }
 warn()    { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
 
-cleanup() {
-  rm -rf "$EXTRACT_DIR"
-}
-trap cleanup EXIT
-
 # ============================================================================
-# 1. Get latest release download URL
+# 1. Prerequisite checks
 # ============================================================================
 
-info "Fetching latest release info from GitHub..."
+info "Checking prerequisites..."
 
-RELEASE_JSON=$(curl -sf "$VERSION_URL" 2>/dev/null) || {
-  error "Failed to fetch release info from GitHub"
-  error "URL: $VERSION_URL"
+# Check gh CLI installed
+command -v gh >/dev/null 2>&1 || {
+  error "GitHub CLI (gh) not installed"
+  error "Install from: https://cli.github.com/"
   exit 1
 }
 
-RELEASE_URL=$(echo "$RELEASE_JSON" | grep -o '"browser_download_url": *"[^"]*\.tar\.gz"' | head -1 | cut -d'"' -f4)
+# Check gh auth
+gh auth status >/dev/null 2>&1 || {
+  error "Not authenticated with GitHub CLI"
+  error "Run: gh auth login"
+  exit 1
+}
 
-if [ -z "$RELEASE_URL" ]; then
-  error "Failed to find .tar.gz download URL in latest release"
-  error "Check: https://github.com/${REPO}/releases/latest"
+# Check node >= 18
+NODE_VERSION=$(node --version 2>/dev/null | sed 's/v//') || {
+  error "Node.js not installed. Required: >= 18. Install from: https://nodejs.org/"
+  exit 1
+}
+NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+if ! [ "$NODE_MAJOR" -ge 18 ] 2>/dev/null; then
+  error "Node.js >= 18 required (found: v${NODE_VERSION})"
+  error "Upgrade at: https://nodejs.org/"
   exit 1
 fi
 
-ARTIFACT=$(basename "$RELEASE_URL")
-success "Found release: $ARTIFACT"
-
-# ============================================================================
-# 2. Download artifact
-# ============================================================================
-
-info "Downloading $ARTIFACT..."
-curl -L -o "$EXTRACT_DIR/$ARTIFACT" "$RELEASE_URL" || {
-  error "Download failed"
-  exit 1
-}
-success "Downloaded: $ARTIFACT"
-
-# ============================================================================
-# 3. Extract
-# ============================================================================
-
-info "Extracting..."
-tar xzf "$EXTRACT_DIR/$ARTIFACT" -C "$EXTRACT_DIR" || {
-  error "Extraction failed"
+# Check npm
+command -v npm >/dev/null 2>&1 || {
+  error "npm not found"
   exit 1
 }
 
-EXTRACTED_DIR=$(ls -d "$EXTRACT_DIR/epost_agent_kit-"* 2>/dev/null | head -1)
-
-if [ -z "$EXTRACTED_DIR" ]; then
-  error "Could not find extracted directory (expected epost_agent_kit-X.Y.Z/)"
-  exit 1
-fi
-
-success "Extracted: $(basename "$EXTRACTED_DIR")"
+success "Prerequisites OK (node v${NODE_VERSION})"
 
 # ============================================================================
-# 4. Install
+# 2. Clone or update CLI repo to persistent location
 # ============================================================================
 
-info "Installing to $INSTALL_DIR..."
 mkdir -p "$INSTALL_DIR"
 
-cp -r "$EXTRACTED_DIR/packages" "$INSTALL_DIR/"
-cp "$EXTRACTED_DIR/.epost-metadata.json" "$INSTALL_DIR/"
-
-if [ -d "$EXTRACTED_DIR/profiles" ]; then
-  cp -r "$EXTRACTED_DIR/profiles" "$INSTALL_DIR/"
+if [ -d "$CLI_DIR/.git" ]; then
+  info "Existing installation found at $CLI_DIR — updating..."
+  cd "$CLI_DIR"
+  git pull origin "$CLI_BRANCH" || {
+    error "git pull failed. Try re-running the installer."
+    exit 1
+  }
+else
+  info "Cloning CLI repository to $CLI_DIR..."
+  gh repo clone "$CLI_REPO" "$CLI_DIR" -- --branch "$CLI_BRANCH" || {
+    error "Clone failed. Check your GitHub access to $CLI_REPO"
+    exit 1
+  }
 fi
 
-if [ -d "$EXTRACTED_DIR/templates" ]; then
-  cp -r "$EXTRACTED_DIR/templates" "$INSTALL_DIR/"
-fi
-
-success "Installed to $INSTALL_DIR"
+success "Repository ready"
 
 # ============================================================================
-# 5. Done
+# 3. Build
+# ============================================================================
+
+cd "$CLI_DIR"
+
+info "Installing dependencies..."
+npm install || { error "npm install failed"; exit 1; }
+
+info "Building..."
+npm run build || { error "npm run build failed"; exit 1; }
+
+success "Build complete"
+
+# ============================================================================
+# 4. Link globally (with sudo fallback on EACCES)
+# ============================================================================
+
+info "Linking CLI globally..."
+npm link 2>/dev/null || {
+  warn "Permission denied, retrying with sudo..."
+  sudo npm link || {
+    error "npm link failed. Run manually:"
+    error "  cd $CLI_DIR && sudo npm link"
+    exit 1
+  }
+}
+
+success "CLI linked globally"
+
+# ============================================================================
+# 5. Verify installation
+# ============================================================================
+
+epost-kit --version >/dev/null 2>&1 || {
+  error "Verification failed — epost-kit not found in PATH"
+  error "Try restarting your terminal or check npm bin is in PATH:"
+  error "  npm config get prefix"
+  exit 1
+}
+
+INSTALLED_VERSION=$(epost-kit --version 2>/dev/null)
+success "Installed: epost-kit ${INSTALLED_VERSION}"
+
+# ============================================================================
+# 6. Done
 # ============================================================================
 
 printf "\n${GREEN}Installation complete!${NC}\n\n"
 printf "  ${BLUE}Next steps:${NC}\n"
-printf "    Install the CLI globally:\n"
-printf "      npm install -g epost-agent-kit-cli\n\n"
-printf "    Or use via npx:\n"
-printf "      npx epost-agent-kit-cli init\n\n"
-printf "    Then run in your project:\n"
-printf "      epost-kit init\n\n"
+printf "    epost-kit init     # Set up kit in your project\n"
+printf "    epost-kit doctor   # Check installation health\n\n"

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,6 +1,6 @@
 /**
  * Command: epost-kit upgrade
- * Self-update CLI to latest version from npm registry
+ * Self-update CLI via git pull + rebuild from ~/.epost-kit/cli/
  */
 
 import { confirm } from '@inquirer/prompts';
@@ -9,8 +9,6 @@ import pc from 'picocolors';
 import { logger } from '@/shared/logger.js';
 import {
   checkForUpdate,
-  detectPackageManager,
-  getUpdateCommand,
   executeUpdate,
   verifyUpdate,
   getChangelogPreview,
@@ -21,35 +19,34 @@ export async function runUpgrade(opts: UpdateOptions): Promise<void> {
   const spinner = ora('Checking for updates...').start();
 
   try {
-    // Check current vs latest version
     const { current, latest, updateAvailable } = await checkForUpdate();
     spinner.stop();
 
     if (!updateAvailable) {
-      logger.info(`Already on latest version: ${pc.green(current)}`);
+      logger.info(`Already up to date: ${pc.green(current)}`);
       return;
     }
 
     // Show version difference
-    logger.info(`Current version: ${pc.yellow(current)}`);
-    logger.info(`Latest version:  ${pc.green(latest)}`);
+    logger.info(`Current: ${pc.yellow(current)}`);
+    logger.info(`Latest:  ${pc.green(latest)}`);
     logger.info('');
 
-    // Fetch changelog preview
+    // Show changelog preview
     const changelog = await getChangelogPreview(current, latest);
     logger.info(changelog);
     logger.info('');
 
     // If --check flag, just report and exit
     if (opts.check) {
-      logger.info('Use `epost-kit upgrade` to install the latest version');
+      logger.info('Run `epost-kit upgrade` to update');
       return;
     }
 
     // Confirm update unless --yes flag
     if (!opts.yes) {
       const shouldUpdate = await confirm({
-        message: 'Update to latest version?',
+        message: 'Update now?',
         default: true,
       });
 
@@ -59,31 +56,27 @@ export async function runUpgrade(opts: UpdateOptions): Promise<void> {
       }
     }
 
-    // Detect package manager
-    const pm = await detectPackageManager();
-    logger.info(`Detected package manager: ${pc.cyan(pm)}`);
-
-    // Execute update
-    spinner.start('Updating CLI...');
+    // Execute update via git pull + rebuild
+    spinner.start('Pulling latest changes and rebuilding...');
     try {
-      await executeUpdate(pm);
+      await executeUpdate();
       spinner.stop();
     } catch (error) {
       spinner.stop();
       logger.error('Update failed');
       logger.info('');
-      logger.info('Please update manually:');
-      logger.info(`  ${pc.cyan(getUpdateCommand(pm))}`);
+      logger.info('Update manually:');
+      logger.info(`  ${pc.cyan('cd ~/.epost-kit/cli && git pull origin master && npm install && npm run build')}`);
       throw error;
     }
 
-    // Verify update succeeded
+    // Verify
     const verified = await verifyUpdate(latest);
     if (verified) {
-      logger.success(`Successfully updated to version ${pc.green(latest)}`);
+      logger.success(`Successfully updated to ${pc.green(latest)}`);
     } else {
-      logger.warn('Update completed but version verification failed');
-      logger.info('Run `epost-kit --version` to check installed version');
+      logger.warn('Update completed but verification inconclusive');
+      logger.info('Run `epost-kit --version` to check');
     }
   } catch (error) {
     spinner.stop();

--- a/src/domains/versioning/self-update.ts
+++ b/src/domains/versioning/self-update.ts
@@ -1,17 +1,31 @@
 /**
  * CLI self-update functionality
- * Detects package manager, checks for updates, fetches changelog
+ * Uses git pull + rebuild from ~/.epost-kit/cli/ (installed via install script)
  */
 
 import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
-import { APP_NAME } from '@/shared/constants.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export type PackageManager = 'npm' | 'pnpm' | 'yarn';
+/** Get the persistent CLI install directory */
+function getCliDir(): string {
+  return join(homedir(), '.epost-kit', 'cli');
+}
+
+/** Assert CLI was installed via install script (has a .git directory) */
+function assertGitInstall(cliDir: string): void {
+  if (!existsSync(join(cliDir, '.git'))) {
+    throw new Error(
+      `CLI not installed via install script (expected git repo at ${cliDir}).\n` +
+      `Run the install script to set up: install/install.sh`
+    );
+  }
+}
 
 /** Read current CLI version from package.json */
 export async function getCurrentVersion(): Promise<string> {
@@ -25,95 +39,69 @@ export async function getCurrentVersion(): Promise<string> {
   }
 }
 
-/** Fetch latest version from npm registry */
-export async function getLatestVersion(): Promise<string> {
-  try {
-    const result = await execa('npm', ['view', APP_NAME, 'version']);
-    return result.stdout.trim();
-  } catch (error) {
-    throw new Error(`Failed to fetch latest version: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  }
+/** Get short git SHA for local HEAD in install dir */
+async function getLocalSha(cliDir: string): Promise<string> {
+  const result = await execa('git', ['rev-parse', '--short', 'HEAD'], { cwd: cliDir });
+  return result.stdout.trim();
 }
 
-/** Check if update is available */
+/** Fetch origin and return short SHA of origin/master */
+async function getRemoteSha(cliDir: string): Promise<string> {
+  await execa('git', ['fetch', 'origin', 'master'], { cwd: cliDir });
+  const result = await execa('git', ['rev-parse', '--short', 'origin/master'], { cwd: cliDir });
+  return result.stdout.trim();
+}
+
+/** Check if update is available by comparing local vs remote git SHAs */
 export async function checkForUpdate(): Promise<{
   current: string;
   latest: string;
   updateAvailable: boolean;
 }> {
-  const current = await getCurrentVersion();
-  const latest = await getLatestVersion();
+  const cliDir = getCliDir();
+  assertGitInstall(cliDir);
+
+  const current = await getLocalSha(cliDir);
+  const latest = await getRemoteSha(cliDir);
   const updateAvailable = current !== latest;
   return { current, latest, updateAvailable };
 }
 
-/** Detect package manager used to install CLI */
-export async function detectPackageManager(): Promise<PackageManager> {
+/** Execute update: git pull + npm install + npm run build */
+export async function executeUpdate(): Promise<void> {
+  const cliDir = getCliDir();
+  assertGitInstall(cliDir);
+
+  await execa('git', ['pull', 'origin', 'master'], { cwd: cliDir, stdio: 'inherit' });
+  await execa('npm', ['install'], { cwd: cliDir, stdio: 'inherit' });
+  await execa('npm', ['run', 'build'], { cwd: cliDir, stdio: 'inherit' });
+}
+
+/** Get changelog preview via git log between two SHAs */
+export async function getChangelogPreview(fromSha: string, toSha: string): Promise<string> {
+  const cliDir = getCliDir();
   try {
-    // Try to find global installation path (for future use)
-    await execa('npm', ['prefix', '-g']);
-
-    // Check if installed via pnpm
-    try {
-      await execa('pnpm', ['list', '-g', APP_NAME]);
-      return 'pnpm';
-    } catch {
-      // Not installed via pnpm
-    }
-
-    // Check if installed via yarn
-    try {
-      await execa('yarn', ['global', 'list']);
-      return 'yarn';
-    } catch {
-      // Not installed via yarn
-    }
-
-    // Default to npm
-    return 'npm';
+    const result = await execa(
+      'git',
+      ['log', '--oneline', `${fromSha}..${toSha}`],
+      { cwd: cliDir }
+    );
+    const commits = result.stdout.trim();
+    return commits
+      ? `Changes since ${fromSha}:\n${commits}`
+      : `Update available: ${fromSha} → ${toSha}`;
   } catch {
-    return 'npm'; // Fallback to npm
+    return `Update available: ${fromSha} → ${toSha}`;
   }
 }
 
-/** Get update command for package manager */
-export function getUpdateCommand(pm: PackageManager): string {
-  switch (pm) {
-    case 'npm':
-      return `npm install -g ${APP_NAME}@latest`;
-    case 'pnpm':
-      return `pnpm add -g ${APP_NAME}@latest`;
-    case 'yarn':
-      return `yarn global add ${APP_NAME}@latest`;
-  }
-}
-
-/** Execute update via package manager */
-export async function executeUpdate(pm: PackageManager): Promise<void> {
-  const args = pm === 'npm'
-    ? ['install', '-g', `${APP_NAME}@latest`]
-    : pm === 'pnpm'
-    ? ['add', '-g', `${APP_NAME}@latest`]
-    : ['global', 'add', `${APP_NAME}@latest`];
-
-  await execa(pm, args, { stdio: 'inherit' });
-}
-
-/** Verify update succeeded by checking version */
-export async function verifyUpdate(expectedVersion: string): Promise<boolean> {
+/** Verify update succeeded by checking local SHA matches expected */
+export async function verifyUpdate(expectedSha: string): Promise<boolean> {
   try {
-    const current = await getCurrentVersion();
-    return current === expectedVersion;
+    const cliDir = getCliDir();
+    const current = await getLocalSha(cliDir);
+    return current === expectedSha;
   } catch {
     return false;
   }
-}
-
-/** Fetch changelog preview from GitHub (simplified version) */
-export async function getChangelogPreview(fromVersion: string, toVersion: string): Promise<string> {
-  // For now, return a placeholder. Full implementation would:
-  // 1. Fetch GitHub releases API
-  // 2. Parse release notes between versions
-  // 3. Format into readable preview
-  return `Update available: ${fromVersion} → ${toVersion}\n\nSee full changelog at: https://github.com/Klara-copilot/epost_agent_kit/releases`;
 }


### PR DESCRIPTION
## Summary

- **install.sh / install.ps1**: Complete rewrite — prerequisite checks (gh, gh auth, node>=18, npm), clone CLI repo to `~/.epost-kit/cli/` via `gh repo clone`, `git pull` on re-run (idempotent), `npm install + build`, `npm link` with auto-sudo fallback on EACCES, verify `epost-kit --version`
- **install.cmd**: Updated fallback message to use `gh repo clone` instead of `npm install -g`
- **self-update.ts**: Replaced npm registry calls with git SHA comparison; `executeUpdate()` does `git pull + npm install + npm run build` inside `~/.epost-kit/cli/`; removed `detectPackageManager` / `getUpdateCommand`
- **upgrade.ts**: Simplified to use new git-based functions; kept `--check` and `--yes` flags
- **install/README.md**: Updated to reflect new install flow, directory layout (`~/.epost-kit/`), upgrading section, fixed repo references

## Bugs Fixed

| # | Bug | Severity |
|---|-----|----------|
| 1 | CLI never installed — script only copied data files | Critical |
| 2 | `curl` without auth failed on private repo | Critical |
| 3 | Install dir mismatch: `~/.epost/` vs `~/.epost-kit/` | Critical |
| 4 | Wrong npm package name in next steps | Medium |
| 5 | No prerequisite checks | Medium |
| 6 | `upgrade` used npm registry — not published there | High |

## Test plan

- [ ] Run `install.sh` on macOS from scratch — `epost-kit --version` works after
- [ ] Re-run `install.sh` — does `git pull` instead of re-cloning
- [ ] Run `install.ps1` on Windows PowerShell
- [ ] Run `epost-kit upgrade --check` — reports SHA diff
- [ ] Run `epost-kit upgrade` — pulls and rebuilds successfully
- [ ] TypeScript build passes: `npm run build` ✅