### PR TITLE
fix(install): replace base64 -d with jq @base64d for Windows PowerShell compat

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -39,7 +39,7 @@ gh api repos/Klara-copilot/epost-agent-kit-cli/contents/install/install.sh --jq 
 ### Windows (PowerShell)
 
 ```powershell
-$script = gh api repos/Klara-copilot/epost-agent-kit-cli/contents/install/install.ps1 --jq .content | base64 -d; Invoke-Expression $script
+$script = gh api repos/Klara-copilot/epost-agent-kit-cli/contents/install/install.ps1 --jq '.content | @base64d'; Invoke-Expression $script
 ```
 
 ### Windows (Command Prompt)

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -6,6 +6,9 @@
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File install.ps1
 #
+#   One-liner (cross-platform, no base64 dependency):
+#   $script = gh api repos/Klara-copilot/epost-agent-kit-cli/contents/install/install.ps1 --jq '.content | @base64d'; Invoke-Expression $script
+#
 # Requirements:
 #   - GitHub CLI (gh), authenticated
 #   - Node.js >= 18.0.0


### PR DESCRIPTION
## Summary

- Fixes Windows PowerShell install one-liner that failed because `base64` is not a native PowerShell command
- Replaces `--jq .content | base64 -d` with `--jq '.content | @base64d'` which uses jq's built-in base64 decoder (bundled with `gh` CLI)
- Works on Windows, macOS, and Linux without any extra dependencies

## Root Cause

`gh api .../contents/file` returns file content base64-encoded. The original command decoded it via Unix `base64 -d` — unavailable in native Windows PowerShell, causing:
```
base64 : The term 'base64' is not recognized...
Invoke-Expression : Cannot bind argument to parameter 'Command' because it is null.
```

## Fix

**Before:**
```powershell
$script = gh api .../install.ps1 --jq .content | base64 -d; Invoke-Expression $script
```

**After:**
```powershell
$script = gh api .../install.ps1 --jq '.content | @base64d'; Invoke-Expression $script
```

## Test Plan

- [ ] Run the updated one-liner on Windows PowerShell — should execute without errors
- [ ] Run on macOS/Linux — confirm no regression